### PR TITLE
Add TC-compatible signatures and offsets

### DIFF
--- a/Source/Triggernometry/PluginBridges/BridgeNamazu/Modules/CameraModule.cs
+++ b/Source/Triggernometry/PluginBridges/BridgeNamazu/Modules/CameraModule.cs
@@ -8,7 +8,7 @@ namespace Triggernometry.PluginBridges.BridgeNamazu.Modules
     public class CameraModule : ModuleBase
     {
 
-        public Dictionary<string, int> Offsets => Plugin.IsCN ? OffsetsCN : OffsetsGlobal;
+        public Dictionary<string, int> Offsets => Plugin.IsTC ? OffsetsTC : Plugin.IsCN ? OffsetsCN : OffsetsGlobal;
 
         public IntPtr CameraPtrPtr;
         public IntPtr CameraPtr
@@ -175,7 +175,22 @@ namespace Triggernometry.PluginBridges.BridgeNamazu.Modules
             { "MinAngleV", 0x158 },
             { "MaxAngleV", 0x15C },
         };
-
+        
+        // https://github.com/UnknownX7/Hypostasis/blob/c885579451307c18a019bd9dd9933e97a3970f17/Game/Structures/GameCamera.cs
+        public Dictionary<string, int> OffsetsTC = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) // TC 7.2
+        {
+            { "Distance", 0x114 },
+            { "MinDistance", 0x118 },
+            { "MaxDistance", 0x11C },
+            { "FoV", 0x120 },
+            { "MinFoV", 0x124 },
+            { "MaxFoV", 0x128 },
+            { "AngleH", 0x130 },
+            { "AngleV", 0x134 },
+            { "MinAngleV", 0x148 },
+            { "MaxAngleV", 0x14C },
+        };
+        
         // 游戏默认
         public readonly Dictionary<string, float> OriginalParams = new Dictionary<string, float>(StringComparer.OrdinalIgnoreCase)
         {

--- a/Source/Triggernometry/PluginBridges/BridgeNamazu/Modules/EntityModule.cs
+++ b/Source/Triggernometry/PluginBridges/BridgeNamazu/Modules/EntityModule.cs
@@ -22,34 +22,34 @@ namespace Triggernometry.PluginBridges.BridgeNamazu.Modules
         public IntPtr PlayActionTimelinePtr;
         public int TimelineContainerOffset;
 
-        /*Plugin.IsCN ? xx : xx*/
+        /*Plugin.IsTC ? TC : Global*/
         /// <summary> 实体初始坐标相对于实体地址的偏移。</summary>
-        public Func<int> DefaultPosOffset = () => 0x10; 
+        public Func<int> DefaultPosOffset = () => Plugin.IsTC ? 0x10 : 0x10;
         /// <summary> 实体 ID 相对于实体地址的偏移。</summary>
-        public Func<int> IdOffset = () => 0x78; // 6.0 / 7.3
+        public Func<int> IdOffset = () => Plugin.IsTC ? 0x74 : 0x78; // 6.0 / 7.3
         /// <summary> 实体坐标相对于实体地址的偏移。</summary>
-        public Func<int> PosOffset = () => 0xB0; // 7.2 / 7.3
+        public Func<int> PosOffset = () => Plugin.IsTC ? 0xA0 : 0xB0; // 7.2 / 7.3
         /// <summary> 实体缩放倍率相对于实体地址的偏移。</summary>
-        public Func<int> ScaleOffset = () => 0xC4; // 7.2 / 7.3
+        public Func<int> ScaleOffset = () => Plugin.IsTC ? 0xB4 : 0xC4; // 7.2 / 7.3
         /// <summary> 实体模型的相对偏移相对于实体地址的偏移。相对坐标偏移会影响实体绘制的模型显示的位置。</summary>
-        public Func<int> ModelRelPosOffset = () => 0xE0; // 7.2 / 7.3
+        public Func<int> ModelRelPosOffset = () => Plugin.IsTC ? 0xD0 : 0xE0; // 7.2 / 7.3
         /// <summary> 实体模型（DrawObject*）相对于实体地址的偏移。</summary>
-        public Func<int> ModelOffset = () => 0x100; // 7.2 / 7.3
+        public Func<int> ModelOffset = () => Plugin.IsTC ? 0xF0 : 0x100; // 7.2 / 7.3
         /// <summary> 实体 StatusLoopVfx ID 相对于实体地址的偏移。</summary>
-        public Func<int> StatusLoopVfxOffset = () => 0x1C8; // 7.2 / 7.3
+        public Func<int> StatusLoopVfxOffset = () => Plugin.IsTC ? 0x28 : 0x1C8; // 7.2 / 7.3
         /// <summary> 实体透明度相对于实体地址的偏移。</summary>
-        public Func<int> OpacityOffset = () => 0x22E8; // 7.4; 7.3 0x22D8 
+        public Func<int> OpacityOffset = () => Plugin.IsTC ? 0x2258 : 0x22E8; // 7.4; 7.3 0x22D8 
         /// <summary> 实体 ModelStatus (RenderFlags) 相对于实体地址的偏移。</summary>
         /// https://github.com/xivdev/Penumbra/blob/master/Penumbra/Interop/Structs/DrawState.cs
-        public Func<int> ModelStatusOffset = () => 0x118; // 7.2 / 7.3
+        public Func<int> ModelStatusOffset = () => Plugin.IsTC ? 0x108 : 0x118; // 7.2 / 7.3
 
         /// <summary> 硬目标地址相对于实体 TargetSystem 地址的偏移（SoftTarget 地址在此基础上 +0x8）。</summary>
-        public Func<int> HardTargetOffset = () => 0x80; // 7.0
+        public Func<int> HardTargetOffset = () => Plugin.IsTC ? 0x80 : 0x80; // 7.0
 
         /// <summary> 模型坐标相对于模型地址的偏移。</summary>
-        public Func<int> ModelPosOffset = () => 0x50; // 6.0
+        public Func<int> ModelPosOffset = () => Plugin.IsTC ? 0x50 : 0x50; // 6.0
         /// <summary> 模型缩放倍率相对于模型地址的偏移。</summary>
-        public Func<int> ModelScaleOffset = () => 0x70; // 6.0
+        public Func<int> ModelScaleOffset = () => Plugin.IsTC ? 0x70 : 0x70; // 6.0
 
         /// <summary> EnableDraw 虚函数索引。</summary>
         public Func<int> EnableDrawVTableIdx = () => 12; // 7.0

--- a/Source/Triggernometry/PluginBridges/BridgeNamazu/Modules/EnvironmentEffectModule.cs
+++ b/Source/Triggernometry/PluginBridges/BridgeNamazu/Modules/EnvironmentEffectModule.cs
@@ -27,10 +27,16 @@ namespace Triggernometry.PluginBridges.BridgeNamazu.Modules
             {
                 // ECommons/ECommons/Hooks/MapEffect.cs
                 // 原始 sig: 48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 8B FA 41 0F B7 E8
-                MapEffectOldFunctionPtr = Scanner.TryScan("44 0F B7 40 ? E9 * * * * C3", nameof(MapEffectOldFunctionPtr));
+                MapEffectOldFunctionPtr = Scanner.TryScanMultiple(new string[] {
+                    "44 0F B7 40 ? E9 * * * * C3", // 原版
+                    "E9 * * * * C3 CC CC CC CC CC CC CC CC CC CC CC CC CC CC CC CC 4C 8B 81 E8 0C 00 00 4D 85 C0 74" // 7.2TC
+                }, nameof(MapEffectOldFunctionPtr));
                 // 上面函数的下一层
                 // 原始 sig：48 89 6C 24 ?? 56 48 83 EC ?? 8B C2 41 0F B7 E8 45 33 C0 48 8D 14 40 48 8B 81 ?? ?? ?? ?? B1 ??
-                MapEffectFunctionPtr = Scanner.TryScan("E8 * * * * 3C ? 75 ? 80 64 B3 ? ?", nameof(MapEffectFunctionPtr));
+                MapEffectFunctionPtr = Scanner.TryScanMultiple(new string[] {
+                    "E8 * * * * 3C ? 75 ? 80 64 B3 ? ?", // 原版
+                    "44 0F B7 C5 8B D7 48 8B CE E8 * * * * 3A C3 75 ? 32 DB" // 7.2TC
+                }, nameof(MapEffectFunctionPtr));
                 // ffcs EventFramework.Instance
                 EventFrameworkPtrPtr = Scanner.TryScan("48 83 3D * * * * * 74 ? E8 ? ? ? ? 48 8B C8 E8 ? ? ? ? 3C", nameof(EventFrameworkPtrPtr)); // 7.3 兼容7.2
                 EnvManagerPtrPtr = Scanner.TryScan("0F 28 F2 48 8B 05 * * * *", nameof(EnvManagerPtrPtr));

--- a/Source/Triggernometry/PluginBridges/BridgeNamazu/Modules/ShowTextGimmickHintModule.cs
+++ b/Source/Triggernometry/PluginBridges/BridgeNamazu/Modules/ShowTextGimmickHintModule.cs
@@ -28,6 +28,7 @@ namespace Triggernometry.PluginBridges.BridgeNamazu.Modules
                     "48 85 D2 0F 84 ?? ?? ?? ?? 4C 8B DC 49 89 6B ?? 56", // 7.3 原始
                     "44 8B CB 45 33 C0 48 8B D0 48 8B CF E8 * * * * E9", // 7.3
                     "44 8B CB 41 B0 01 48 8B D0 48 8B CF E8 * * * * E9", // 7.3 备用签名
+                    "44 8B CE 48 8B C8 48 8B D7 E8 * * * * E9 ? ? ? ? 66 0F BA E6 0A 0F 83 ? ? ? ?", // 7.2TC
                 }, nameof(ShowTextGimmickHintPtr));
             };
         }

--- a/Source/Triggernometry/PluginBridges/BridgeNamazu/Modules/UseActionModule.cs
+++ b/Source/Triggernometry/PluginBridges/BridgeNamazu/Modules/UseActionModule.cs
@@ -23,6 +23,7 @@ namespace Triggernometry.PluginBridges.BridgeNamazu.Modules
                 UseActionLocationPtr = Scanner.TryScanMultiple(new string[] {
                     "E8 * * * * 48 8B BC 24 ? ? ? ? 44 0F B6 F8 B0", // 7.4
                     "E8 * * * * 40 3A C7 0F 85", // 7.3
+                    "E8 * * * * 41 3A C5 0F 85", // 7.2 TC
                 }, nameof(UseActionLocationPtr));
 
                 ActionManagerPtr = Scanner.TryScan(

--- a/Source/Triggernometry/PluginBridges/BridgeNamazu/NamazuPlugin.cs
+++ b/Source/Triggernometry/PluginBridges/BridgeNamazu/NamazuPlugin.cs
@@ -142,6 +142,7 @@ namespace Triggernometry.PluginBridges.BridgeNamazu
 
         // Region detection
         public bool IsCN => _plugin.IsCN;
+        public bool IsTC => FFXIV.GameLanguage.Language == FFXIV.GameLanguageEnum.TCN;
         public IntPtr FrameworkPtr => _plugin.FrameworkPtr;
 
     }


### PR DESCRIPTION
## Summary

This PR adds TC compatibility updates for several Namazu bridge modules.

Changes include:

- Add TC-compatible callsite signature for `ShowTextGimmickHintModule`.
- Add TC-compatible relative-addressing signatures for `EnvironmentEffectModule` / MapEffect.
- Add TC version offsets for `EntityModule`.
- Add TC version offsets for `CameraModule`.
- Keep existing signatures and offsets for other supported clients.